### PR TITLE
chore: permission boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ GitHub CD pipeline scripts are triggered based on the directory that has changed
 1. `Grafana`: deploys the `Grafana` dashboard with the two `datasources` configured above.
 1. `Promtail`: deploys the `Promtail` in multiple namespaces to collect the Keycloak disk logs.
 
+The terraform account for deployment is restricted to the required resource types for this repository. If adding new resources not currently required, you will get a permission denied error. Expand the permissions on the `sso-dashboard-boundary` as needed.
+
 ## GitHub secrets
 
 The following secrets are set in the GitHub secrets of the repository and can be found in [OCP secret](https://console.apps.silver.devops.gov.bc.ca/k8s/ns/6d70e7-tools/secrets/sso-team-sso-dashboard-github-secrets)

--- a/terraform-ecs/providers.tf
+++ b/terraform-ecs/providers.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = {
+      repository = "sso-dashboard"
+    }
+  }
 }
 
 terraform {

--- a/terraform-ecs/roles.tf
+++ b/terraform-ecs/roles.tf
@@ -1,6 +1,11 @@
+data "aws_iam_policy" "permissions_boundary_policy" {
+    name = "sso-dashboard-boundary"
+}
+
 # Execution role, permissions to log to cloudwatch
 resource "aws_iam_role" "loki_execution_role" {
   name = "loki-execution-role"
+  permissions_boundary = data.aws_iam_policy.permissions_boundary_policy.arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -17,6 +22,7 @@ resource "aws_iam_role" "loki_execution_role" {
 
 resource "aws_iam_policy" "loki_execution_policy" {
   name        = "loki-execution-policy"
+  permissions_boundary = data.aws_iam_policy.permissions_boundary_policy.arn
   description = "Permissions for ECS task execution, including logging to CloudWatch"
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
Add restrictions for terraform deployments. I updated the policy for the deployer role in dev, `
PathfinderSSODashboardDevTfDeployRole` with two policies:

- `sso-dashboard-boundary`: Restricted to only the resources this repository uses:

```js
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Allow",
            "Effect": "Allow",
            "Action": [
                "s3:*",
                "apigateway:*",
                "lambda:*",
                "ecs:*",
               // ec2 needed to view subnets and vpcs and create security groups
                "ec2:*",
                "elasticloadbalancing:*",
                "application-autoscaling:*",
                "cloudwatch:*"
            ],
            "Resource": "*"
        }
    ]
}
```

- `sso-dashboard-iam-boundary`: This gives it limited IAM permissions, so that it can only create roles if they have the `sso-dashboard-boundary` added as a permissions boundary. It also denies removing or updating the sso-dashboard-boundary so it can't remove it after. 

This works well, I tested the deployer role cannot create roles without the permission boundary, and the boundary on the created role work as expected blocking any un-listed resources, regardless of other policies in place. The implementation is largely based on this [aws blog post](https://aws.amazon.com/blogs/security/when-and-where-to-use-iam-permissions-boundaries/#:~:text=A%20permissions%20boundary%20is%20an,Amazon%20Web%20Services%20(AWS)) I found after you gave me the idea boundaries could solve this.

For the code change I added the boundary to the roles, it needs it now or will get forbidden in CI, and also tagged resources for this account so it is easy to see which role owns resources in the console