### PR TITLE
fix: rocketchat err

### DIFF
--- a/aggregator/model/client_sessions_test.go
+++ b/aggregator/model/client_sessions_test.go
@@ -1,24 +1,28 @@
 package model
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"sso-dashboard.bcgov.com/aggregator/keycloak"
+	"sso-dashboard.bcgov.com/aggregator/webhooks"
 )
 
 type MockRocketChat struct {
 	Messages [][]string
 }
 
-func (m *MockRocketChat) NotifyRocketChat(text string, title string, body string) {
+func (m *MockRocketChat) NotifyRocketChat(text string, title string, body string) error {
 	message := []string{text, title, body}
 	m.Messages = append(m.Messages, message)
+	return nil
 }
 
 func (m *MockRocketChat) ResetMock() {
@@ -179,5 +183,31 @@ func TestClientContinue(t *testing.T) {
 	GetClientStats(rm, []string{"realm 1", "realm 2", "realm 3"}, "dev")
 	if requestCount != 3 {
 		t.Errorf("Expeted all realm requests to be attempted even if one fails")
+	}
+}
+
+func TestNotifyRocketChat(t *testing.T) {
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
+
+	// Run a closed server simulating rocket chat being down
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+	os.Setenv("RC_WEBHOOK", server.URL)
+
+	rc := &webhooks.RocketChat{}
+
+	// Notify should return error, not throw error
+	err := rc.NotifyRocketChat("Test", "Title", "Body")
+
+	if err == nil {
+		t.Fatal("Expected a returned error when RC Server is down")
+	}
+
+	logOutput := logBuf.String()
+
+	if !strings.Contains(logOutput, "Error sending rocket chat notification") {
+		t.Errorf("Expected log to contain 'Error sending rocket chat notification', got: %s", logOutput)
 	}
 }

--- a/aggregator/webhooks/index.go
+++ b/aggregator/webhooks/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type RocketChatNotifier interface {
-	NotifyRocketChat(text string, title string, body string)
+	NotifyRocketChat(text string, title string, body string) error
 }
 
 type RocketChat struct{}
@@ -18,7 +18,7 @@ type RocketChat struct{}
 /*
 For the RC webhook, text will appear at the top, with a title and collapsible body below.
 */
-func (r *RocketChat) NotifyRocketChat(text string, title string, body string) {
+func (r *RocketChat) NotifyRocketChat(text string, title string, body string) error {
 	// HTTP endpoint
 	log.Println("Sending rocket chat notification")
 	posturl := utils.GetEnv("RC_WEBHOOK", "")
@@ -37,21 +37,25 @@ func (r *RocketChat) NotifyRocketChat(text string, title string, body string) {
 	requestBody := []byte(fmt.Sprintf(requestBodyTemplate, text, title, body))
 
 	// Create a HTTP post request
-	resp, err := http.NewRequest("POST", posturl, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", posturl, bytes.NewBuffer(requestBody))
 	if err != nil {
 		log.Println("Error sending rocket chat notification", err)
+		return err
 	}
-	resp.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
-	res, err := client.Do(resp)
+	res, err := client.Do(req)
 
 	if err != nil {
 		log.Println("Error sending rocket chat notification", err)
+		return err
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		log.Println("Error sending rocket chat notification", res.Status, res.Body)
+		return fmt.Errorf("received non-200 response: %s", res.Status)
 	}
 
 	defer res.Body.Close()
+	return nil
 }


### PR DESCRIPTION
Rocketchat notifier was not returning error, causing a nil pointer exception on `res.StatusCode`. Fixes this and adds a unit test