### PR TITLE
chore: alloy config

### DIFF
--- a/helm/alloy/README.md
+++ b/helm/alloy/README.md
@@ -13,3 +13,7 @@ They can be saved in a `.env` file if deploying with the local Makefile.
 ## Installing
 
 After setting environment variables and logging into the correct env, set the NAMESPACE argument in the makefile and run `make install`. If adjusting values, the app will deploy when merged to dev/main.
+
+## Legacy Migration
+
+This alloy instance was migrated from existing promtail instances after they were deprecated. To keep the log positions, the promtail PVC is mounted on this instance, named `sso-promtail-aggregator-positions`. See the [legacy positions file](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.file/#arguments) argument for more details.

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -77,7 +77,7 @@ alloy:
           }
 
           stage.drop {
-            older_than          = "16h"
+            older_than          = "10h"
             drop_counter_reason = "too old"
           }
 

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -19,7 +19,7 @@ alloy:
       }
 
       local.file_match "tmplogs" {
-          path_targets = [{"__path__" = "/alloy-logs/*.log"}]
+          path_targets = [{"__path__" = "/keycloak/logs/*.log"}]
       }
 
       loki.source.file "local_files" {
@@ -30,11 +30,6 @@ alloy:
 
       loki.process "loki" {
         forward_to = [loki.write.loki.receiver]
-
-        stage.drop {
-          older_than          = "10h"
-          drop_counter_reason = "too old"
-        }
 
         stage.static_labels {
             values = {
@@ -53,15 +48,15 @@ alloy:
             source = "timestamp"
             format = "RFC3339Nano"
         }
+
+        stage.drop {
+          older_than          = "10h"
+          drop_counter_reason = "too old"
+        }
       }
 
       loki.process "aggregator" {
         forward_to = [loki.write.aggregator.receiver]
-
-          stage.drop {
-            older_than          = "10h"
-            drop_counter_reason = "too old"
-          }
 
           stage.static_labels {
               values = {
@@ -79,6 +74,11 @@ alloy:
           stage.timestamp {
               source = "timestamp"
               format = "RFC3339Nano"
+          }
+
+          stage.drop {
+            older_than          = "16h"
+            drop_counter_reason = "too old"
           }
 
           stage.regex {
@@ -119,12 +119,9 @@ alloy:
     extra:
       - name: positions
         mountPath: /mnt/alloy
-        # keeping previous promtail positions to prevent re-sending logs
-        existingClaim: sso-promtail-aggregator-positions
         readOnly: false
       - name: keycloak-logs
-        mountPath: /alloy-logs
-        existingClaim: sso-keycloak-logs
+        mountPath: /keycloak/logs
         readOnly: true
 
   resources:


### PR DESCRIPTION
- Update the logs pvc mount to have same path as promtail did, to ensure positions file gets picked up (filename and full path must match promtail)
- Move the drop stage for old logs to after the timestamp labelling, was failing to read the timestamp before it was re-formatted